### PR TITLE
Modify 'Save As' URLs for nicer linking site-wide

### DIFF
--- a/content/W2015/W15-blog-20150105.md
+++ b/content/W2015/W15-blog-20150105.md
@@ -12,6 +12,6 @@ on GitHub](https://github.com/wics-uw/website). You can find documentation on
 how to contribute the site in the README.
 
 We'll be occasionally posting news and other information on our 
-[blog](/category/blog.html). Check out the [Events 
-section](/category/events.html) for our upcoming events, and the [Media 
-section](/category/media.html) for recordings of past talks.
+[blog](/category/blog/). Check out the [Events section](/category/events/) for
+our upcoming events, and the [Media section](/category/media/) for recordings
+of past talks.

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -15,8 +15,22 @@ EXTRA_PATH_METADATA = {
         {'path': 'favicon.ico'},
 }
 
-ARTICLE_URL = '{date:%Y}/{date:%m}/{slug}.html'
-ARTICLE_SAVE_AS = '{date:%Y}/{date:%m}/{slug}.html'
+ARTICLE_URL = '{date:%Y}/{date:%m}/{slug}/'
+ARTICLE_SAVE_AS = '{date:%Y}/{date:%m}/{slug}/index.html'
+
+PAGE_URL = '{slug}/'
+PAGE_SAVE_AS = '{slug}/index.html'
+
+CATEGORY_URL = '{slug}/'
+CATEGORY_SAVE_AS = '{slug}/index.html'
+
+TAGS_SAVE_AS = 'tags/index.html'
+TAG_URL = 'tag/{slug}/'
+TAG_SAVE_AS = 'tags/{slug}/index.html'
+
+AUTHOR_URL = 'author/{slug}/'
+AUTHOR_SAVE_AS = 'author/{slug}/index.html'
+
 
 TIMEZONE = 'Canada/Eastern'
 

--- a/themes/notmyidea/templates/base.html
+++ b/themes/notmyidea/templates/base.html
@@ -34,7 +34,7 @@
                     <li{% if cat == category %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a></li>
                 {% endfor %}
                 {% endif %}
-                    <li{% if output_file == "tags.html" %} class="active"{% endif %}><a href="/tags.html">Tags</a></li>
+                    <li{% if output_file == "tags.html" %} class="active"{% endif %}><a href="/tags/">Tags</a></li>
                 </ul></nav>
         </header><!-- /#banner -->
         {% block content %}


### PR DESCRIPTION
This pull request completely changes how the site is generated.

It's also _awesome_ because it allows us to link to, say, `wics.uwaterloo.ca/calendar` instead of `calendar.html`.
