### PR TITLE
Tweak calendar settings

### DIFF
--- a/content/pages/calendar.md
+++ b/content/pages/calendar.md
@@ -7,6 +7,6 @@ Summary: Calendar of Events
 You can check out our upcoming events on our Google Calendar:
 
 <iframe 
-src="https://www.google.com/calendar/embed?src=wics.ugrad%40gmail.com&ctz=America/Toronto" 
-style="border: 0" width="760" height="600" frameborder="0" 
+src="https://www.google.com/calendar/embed?title=Women%20in%20Computer%20Science%20Undergraduate%20Committee%20Calendar&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;height=650&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=1j2vf715pvpi96h9k7cn8trnb4%40group.calendar.google.com&amp;color=%23333333&amp;src=wics.ugrad%40gmail.com&amp;color=%23711616&amp;ctz=America%2FToronto"
+style=" border-width:0 " width="860" height="650" frameborder="0"
 scrolling="no"></iframe>


### PR DESCRIPTION
When we widened the site and added the Tags section to the menu bar,
the Google Calendar widget wasn't modified with it.

Additionally, I've also embedded the CS exams calendar and changed the
colors.
