### PR TITLE
Fixing broken links to /blog, /events, and /media in the first blog post

### DIFF
--- a/content/W2015/W15-blog-20150105.md
+++ b/content/W2015/W15-blog-20150105.md
@@ -12,6 +12,6 @@ on GitHub](https://github.com/wics-uw/website). You can find documentation on
 how to contribute the site in the README.
 
 We'll be occasionally posting news and other information on our 
-[blog](/category/blog/). Check out the [Events section](/category/events/) for
-our upcoming events, and the [Media section](/category/media/) for recordings
+[blog](/blog). Check out the [Events section](/events) for
+our upcoming events, and the [Media section](/media) for recordings
 of past talks.


### PR DESCRIPTION
Regarding issue #38

I'm not sure if the link structure is correct? I don't really know how pelican works/what its standards are.
