### PR TITLE
Fix error and warning that was preventing page generation

### DIFF
--- a/content/S2015/S15-event-teaparty.md
+++ b/content/S2015/S15-event-teaparty.md
@@ -1,8 +1,8 @@
-itle: Big CSters Tea Party Social
+title: Big CSters Tea Party Social
 Date: 2015-05-11 18:30
 Category: Events
 Tags: social, big csters
-Slug: tea-party 
+Slug: tea-party-s15 
 Author: Anna Lorimer 
 Summary: We'll be meeting up in the CS lounge for a tea party social!
 


### PR DESCRIPTION
The "title" key was munged as "itle" so this article wasn't getting rendered.

It had the same slug as a W15 event so it was being processed as a translation.
