### PR TITLE
Add video page for co-op showcase

### DIFF
--- a/content/W2015/W15-media-coop.md
+++ b/content/W2015/W15-media-coop.md
@@ -1,0 +1,23 @@
+Title: Co-op Showcase Panel
+Date: 2015-01-19 23:00
+Category: Media
+Tags: industry, panels
+Slug: coop-video
+Author: Elana Hashman
+Summary: Upper year students showcase their co-op experience to help junior students in their job hunt this term.
+
+You can find more information about the event
+[here]({filename}/W2015/W15-event-coop.md).
+
+From left to right, this panel featured panelists
+[Sarah Harvey](https://cs.uwaterloo.ca/~sharvey/),
+[Elana Hashman](https://hashman.ca/), [Julia Nguyen](http://julianguyen.org/),
+[Luxsumi Jeevananthan](https://ca.linkedin.com/pub/luxsumi-jeevananthan/84/622/620),
+and moderator Anna Lorimer.
+
+
+<video width="320" height="240" controls>
+  <source src="http://mirror.csclub.uwaterloo.ca/wics/coop-panel-w15.mp4"
+          type="video/mp4">
+Your browser does not support the video tag.
+</video>


### PR DESCRIPTION
Fixes #101

The video isn't up yet, but this will allow me to test it on the review app once we upload it to mirror.csclub, hopefully tonight.

The delay on this PR was caused by poor audio quality. (While I just rebased this commit so the date says Dec. 2nd, it's originally from March.) @pbarfuss and I have been working to run it through a denoising filter to improve it.
