### PR TITLE
Fixed Mary Wells' link on f2014 fem101 panel page

### DIFF
--- a/content/F2014/F14-media-feminism101.md
+++ b/content/F2014/F14-media-feminism101.md
@@ -16,7 +16,7 @@ Ragde](https://cs.uwaterloo.ca/faculty-staff/contacts/prabhakar-ragde),
 [Dr. Carla Fehr](https://uwaterloo.ca/philosophy/people-profiles/carla-fehr),
 [Dr. Aim&eacute;e 
 Morrison](https://uwaterloo.ca/english/people-profiles/aimee-morrison),
-[Dr. Mary Wells](https://uwaterloo.ca/english/people-profiles/aimee-morrison)
+[Dr. Mary Wells](https://uwaterloo.ca/mechanical-mechatronics-engineering/people-profiles/mary-wells)
 and [Elana Hashman](https://hashman.ca).
 
 <video width="320" height="240" controls>


### PR DESCRIPTION
Noticed that Mary Wells' link actually pointed to Morrison's page. Changed to point at Mary Wells' page.

Tell me if I'm missing some WiCS standards here pls
