### PR TITLE
Add pelican-youtube plugin in pelicanconf.py

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -72,3 +72,8 @@ TWITTER_USERNAME = 'wicsuw'
 DEFAULT_PAGINATION = 5
 
 THEME = 'themes/notmyidea'
+
+# Plug-in
+PLUGINS = [
+    'pelican_youtube'
+]


### PR DESCRIPTION
I followed this [link](https://github.com/kura/pelican_youtube) to install pelican-youtube plugin. This would allow embedding youtube videos in our pages and articles.