### PR TITLE
Fix the video link to the coop panel

### DIFF
--- a/content/F2017/F17-media-coop.md
+++ b/content/F2017/F17-media-coop.md
@@ -13,7 +13,4 @@ Thanks to those awesome women and all who attended our event!
 
 From left to right, this panel featured panelists: Shirley M, Arshia M, Anna L, Amy Q, and Evy K.
 
-.. youtube:: rBieIcS9kwE
-	:class: youtube-4x3
-	:allowfullscreen: no
-	:seamless: no
+Please click this [link to watch the video](www.youtube.com/watch?v=rBieIcS9kwE)


### PR DESCRIPTION
Since the pelican_youtube plugin is not yet fixed, let's replace it with the link to youtube for now. 